### PR TITLE
fixing unit tests that failed due to convenience methods using a diff…

### DIFF
--- a/Example/SGKeychainExampleTests/SGKeychainExampleTests.m
+++ b/Example/SGKeychainExampleTests/SGKeychainExampleTests.m
@@ -53,7 +53,6 @@
     
     self.defaultItem = [[SGKeychainItem alloc] init];
     self.defaultItem.account = self.username;
-    self.defaultItem.accessibility = SGKeychainAccessibilityAfterFirstUnlock;
     self.defaultItem.service = self.service;
 }
 


### PR DESCRIPTION
…erence accessibility group than the one assigned to defaultItem in setUp. The 'isPersisted' check failed due to the accessibility attributes not matching (i.e. it was implicitly set to "kSecAttrAccessibleWhenUnlocked" by default, but explicitly set to "kSecAttrAccessibleAfterFirstUnlock" in the test setUp).

A more robust fix might be to create separate methods for fetch and insertion queries, so fetch queries could be less pedantic (i.e. only include the account/service attributes).